### PR TITLE
List model class generation for Apex

### DIFF
--- a/generator/ClientApiGenerator/Models/MethodInfo.cs
+++ b/generator/ClientApiGenerator/Models/MethodInfo.cs
@@ -28,5 +28,14 @@ namespace ClientApiGenerator.Models
             Regex rgx = new Regex("\\{.+?\\}");
             return rgx.Replace(sentence, "{}");
         }
+
+        /// <summary>
+        /// remove bracket for array type ResponseTypeName, for Apex use only.
+        /// </summary>
+        public string parseBracket(string input)
+        {
+            Regex rgx = new Regex(@"\s|[<>]");
+            return rgx.Replace(input, "");
+        }
     }
 }

--- a/generator/ClientApiGenerator/Render/RenderTarget.cs
+++ b/generator/ClientApiGenerator/Render/RenderTarget.cs
@@ -81,6 +81,11 @@ namespace ClientApiGenerator.Render
                         case TemplateType.enums:
                             RenderEnums(api, template);
                             break;
+
+                        // One file per model that is used by a CRUD method that returns a list (for Apex use)
+                        case TemplateType.listModels:
+                            RenderListModels(api, template);
+                            break;
                     }
                 }
             }
@@ -146,6 +151,28 @@ namespace ClientApiGenerator.Render
                 Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
                 var output = template.razor.ExecuteTemplate(api, null, model, null);
                 File.WriteAllText(outputPath, output);
+            }
+        }
+
+        private void RenderListModels(SwaggerInfo api, RenderTemplateTask template)
+        {
+            foreach (var method in api.Methods)
+            {
+                if (method.ResponseType == "array")
+                {
+                    string modelName = method.parseBracket(method.ResponseTypeName).Substring(4);
+                    foreach (var model in api.Models)
+                    {
+                        if (model.SchemaName.Contains(modelName))
+                        {
+                            var outputPath = Path.Combine(rootFolder, QuickStringMerge(template.output, model));
+                            Directory.CreateDirectory(Path.GetDirectoryName(outputPath));
+                            var output = template.razor.ExecuteTemplate(api, null, model, null);
+                            File.WriteAllText(outputPath, output);
+                            break;
+                        }
+                    }
+                }
             }
         }
 

--- a/generator/ClientApiGenerator/Render/RenderTemplateTask.cs
+++ b/generator/ClientApiGenerator/Render/RenderTemplateTask.cs
@@ -10,7 +10,7 @@ namespace ClientApiGenerator.Render
     /// <summary>
     /// Define the types of templates recognized
     /// </summary>
-    public enum TemplateType { singleFile, methods, methodCategories, models, uniqueModels, enums };
+    public enum TemplateType { singleFile, methods, methodCategories, models, uniqueModels, enums, listModels };
 
     /// <summary>
     /// An execution of a render template

--- a/scripts/avataxapi.json
+++ b/scripts/avataxapi.json
@@ -178,6 +178,11 @@
                     "output": "src\\classes\\{SchemaName}.cls"
                 },
                 {
+                    "file": "templates\\apex_list_model_class.txt",
+                    "type": "listModels",
+                    "output": "src\\classes\\List{SchemaName}.cls"
+                },
+                {
                     "file": "templates\\apex_enum_class.txt",
                     "type": "enums",
                     "output": "src\\classes\\{EnumDataType}.cls"
@@ -191,6 +196,11 @@
                     "file": "templates\\apex_meta.txt",
                     "type": "uniqueModels",
                     "output": "src\\classes\\{SchemaName}.cls-meta.xml"
+                },
+                {
+                    "file": "templates\\apex_meta.txt",
+                    "type": "listModels",
+                    "output": "src\\classes\\List{SchemaName}.cls-meta.xml"
                 }
             ]
         }

--- a/scripts/templates/apex_api_class.txt
+++ b/scripts/templates/apex_api_class.txt
@@ -29,7 +29,11 @@ global class AvaTaxClient
         WriteLine("        // <param name=\'" + p.CleanParamName + "\'>" + ApexComment(p.Comment, 8) + "</param>");
     }
 
-    Write("        public " + m.ResponseTypeName + " " + m.Name + "(");
+    if (m.ResponseType == "array"){
+        Write("    global " + m.parseBracket(m.ResponseTypeName) + " " + m.Name + "(");
+    } else {
+        Write("    global " + m.ResponseTypeName + " " + m.Name + "(");
+    }
 
     bool any = false;
     foreach (var p in m.Params) {
@@ -54,7 +58,7 @@ global class AvaTaxClient
     
     if (m.ResponseType == "array"){
         WriteLine("            httpResponse res = restCallForList(\'" + m.HttpVerb.ToUpper() + "\', path.relativePath, " + (m.BodyParam == null ? "null" : "model") + ");");
-        WriteLine("            " + m.ResponseTypeName + " retVal = new " + m.ResponseTypeName + "();");
+        WriteLine("            " + m.parseBracket(m.ResponseTypeName) + " retVal = new " + m.ResponseTypeName + "();");
         WriteLine("            if(res.getStatusCode() == 200 || res.getStatusCode() == 201)");
         WriteLine("            {");
         WriteLine("                retVal.result = restCallForList(" + m.ResponseTypeName + ")System.JSON.deserialize(res.getBody(), " + m.ResponseTypeName + ".class);");

--- a/scripts/templates/apex_api_class.txt
+++ b/scripts/templates/apex_api_class.txt
@@ -30,9 +30,9 @@ global class AvaTaxClient
     }
 
     if (m.ResponseType == "array"){
-        Write("    global " + m.parseBracket(m.ResponseTypeName) + " " + m.Name + "(");
+        Write("        global " + m.parseBracket(m.ResponseTypeName) + " " + m.Name + "(");
     } else {
-        Write("    global " + m.ResponseTypeName + " " + m.Name + "(");
+        Write("        global " + m.ResponseTypeName + " " + m.Name + "(");
     }
 
     bool any = false;

--- a/scripts/templates/apex_list_model_class.txt
+++ b/scripts/templates/apex_list_model_class.txt
@@ -11,8 +11,8 @@
 /* @ApexComment(ClassModel.Comment, 4) */
 
 @if(true) {
-		WriteLine("global class List" + ClassModel.SchemaName + " extends ErrorResult");
+	WriteLine("global class List" + ClassModel.SchemaName + " extends ErrorResult");
 	WriteLine("{");
-		  WriteLine("    global List<" + ClassModel.SchemaName + "> result { get; set; }");
+	WriteLine("    global List<" + ClassModel.SchemaName + "> result { get; set; }");
 	WriteLine("}");
 }

--- a/scripts/templates/apex_list_model_class.txt
+++ b/scripts/templates/apex_list_model_class.txt
@@ -1,0 +1,18 @@
+/*
+ * AvaTax API Client Library
+ *
+ * (c) 2004-2018 Avalara, Inc.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ */
+
+/* @ApexComment(ClassModel.Comment, 4) */
+
+@if(true) {
+		WriteLine("global class List" + ClassModel.SchemaName + " extends ErrorResult");
+	WriteLine("{");
+		  WriteLine("    global List<" + ClassModel.SchemaName + "> result { get; set; }");
+	WriteLine("}");
+}


### PR DESCRIPTION
For methods that have a return type of list/array, unlike C# the following syntax is not available in Apex 
`public List<AccountConfigurationModel>`
Instead, a specific model needs to be provided: 
`global ListAccountConfigurationModel`

This required additional work since ListAccountConfiguraitonModel is not a model provided by our Swagger doc. 

