### PR TITLE
Added fix for handling Byte parameters.

### DIFF
--- a/generator/ClientApiGenerator/Program.cs
+++ b/generator/ClientApiGenerator/Program.cs
@@ -380,7 +380,14 @@ namespace ClientApiGenerator
 
                 // Base64 encoded bytes
                 if (String.Equals(prop.format, "byte", StringComparison.CurrentCultureIgnoreCase)) {
-                    typename.Append("Byte[]");
+                    if(prop.description == "Content of the batch file.")
+                    {
+                        typename.Append("Byte[]");
+                    }
+                    else
+                    {
+                        typename.Append("Byte");
+                    }
                 } else if (prop.EnumDataType == null) {
                     return "String";
                 } else {


### PR DESCRIPTION
@ted-spence-avalara Here's the bug I found in the SDK generator.  If I'm understanding what was going on correctly; it appeared that previously Byte handling was a special case and was only being used for the Batch model.  The new Audit Account API now also has a Byte type parameter.  That was causing the SDK to throw an error on call when trying to convert the JSON from a byte to byte[]. I kind of hacked a solution together.  Take a look when you get a chance.  We can edit if necessary.