### PR TITLE
Support response type generation for Accepted status code APIs.

### DIFF
--- a/generator/ClientApiGenerator/Program.cs
+++ b/generator/ClientApiGenerator/Program.cs
@@ -197,11 +197,11 @@ namespace ClientApiGenerator
 
                     // Now figure out the response type
                     SwaggerResult ok = null;
-                    if (verb.Value.responses.TryGetValue("200", out ok)) {
-                        api.ResponseType = ok.schema == null ? null : ok.schema.type;
-                        api.ResponseTypeName = ResolveTypeName(ok.schema);
-                    } else if (verb.Value.responses.TryGetValue("201", out ok)) {
-                        api.ResponseType = ok.schema == null ? null : ok.schema.type;
+                    if (verb.Value.responses.TryGetValue("200", out ok)
+                        || verb.Value.responses.TryGetValue("201", out ok)
+                        || verb.Value.responses.TryGetValue("202", out ok)) {
+
+                        api.ResponseType = ok.schema?.type;
                         api.ResponseTypeName = ResolveTypeName(ok.schema);
                     }
 


### PR DESCRIPTION
This allows the swagger generator to build response types based on APIs which return 202 Accepted status codes. Previously, if 202 Accepted was the only "success" response status returned by the API, the `ResponseType` and `ResponseTypeName` properties would be null.