### PR TITLE
DEVCON-3505: Fix SDK Update Templates for JS, C# and Python

### DIFF
--- a/scripts/avataxapi.json
+++ b/scripts/avataxapi.json
@@ -129,12 +129,6 @@
       ],
       "fixups": [
         {
-          "file": "composer.json",
-          "encoding": "ASCII",
-          "regex": "\"version\": \".*\",",
-          "replacement": "\"version\": \"{ApiVersionPeriodsOnly}\","
-        },
-        {
           "file": "src\\Client.php",
           "encoding": "ASCII",
           "regex": "; PhpRestClient; .*; ",

--- a/scripts/avataxapi.json
+++ b/scripts/avataxapi.json
@@ -231,7 +231,7 @@
     },
     {
       "name": "Apex",
-      "rootFolder": "c:\\git\\develop\\vaTax-REST-V2-Apex-SDK",
+      "rootFolder": "c:\\git\\develop\\AvaTax-REST-V2-Apex-SDK",
       "templates": [
         {
           "file": "templates\\apex_api_class.txt",

--- a/scripts/avataxapi.json
+++ b/scripts/avataxapi.json
@@ -127,14 +127,20 @@
           "output": "src\\taxRatesByZip\\README.txt"
         }
       ],
-      "fixups": [
-        {
-          "file": "src\\Client.php",
-          "encoding": "ASCII",
-          "regex": "; PhpRestClient; .*; ",
-          "replacement": "; PhpRestClient; {ApiVersion}; "
-        }
-      ]
+			"fixups": [
+				{
+					"file": "composer.json",
+					"encoding": "ASCII",
+					"regex": "\"version\": \".*\",",
+					"replacement": "\"version\": \"{ApiVersionPeriodsOnly}\","
+				},
+				{
+					"file": "src\\Client.php",
+					"encoding": "ASCII",
+					"regex": "; PhpRestClient; .*; ",
+					"replacement": "; PhpRestClient; {ApiVersion}; "
+				}
+			]
     },
     {
       "name": "JavaScript",

--- a/scripts/templates/csharp_api_class.txt
+++ b/scripts/templates/csharp_api_class.txt
@@ -55,6 +55,8 @@ namespace Avalara.AvaTax.RestClient
         Backtrack(2);
     }
 
+    WriteLine(")");
+    WriteLine("        {");
 	if(m.Name == "AuditAccount") {
 		WriteLine("            string startDate = null;");
 		WriteLine("            string endDate = null; ");
@@ -68,9 +70,6 @@ namespace Avalara.AvaTax.RestClient
 		WriteLine("			      endDate = string.Format(\"{0}{1}\", end.Value.ToString(\"s\"), \"Z\");");
 		WriteLine("            }");
 	}
-
-    WriteLine(")");
-    WriteLine("        {");
     WriteLine("            var path = new AvaTaxPath(\"" + m.URI + "\");");
     foreach (var p in m.Params) {
         // Identify clean parameter name - 
@@ -181,8 +180,8 @@ namespace Avalara.AvaTax.RestClient
 		WriteLine("            return await RestCallStringAsync(\"" + m.HttpVerb.ToUpper() + "\", path, " + (string.IsNullOrEmpty(paramName) ? "null" : paramName) + ").ConfigureAwait(false);");
 	} else if (m.ResponseTypeName == "String") {
         WriteLine("            return await RestCallStringAsync(\"" + m.HttpVerb.ToUpper() + "\", path, " + (m.BodyParam == null ? "null" : "model") + ").ConfigureAwait(false);");
-    } else if (m.ResponseTypeName == "FileResult") {
-        WriteLine("            return RestCallFileAsync + m.HttpVerb.ToUpper() + "\", path, " + (m.BodyParam == null ? "null" : "model") + ");");
+    } else if (m.ResponseTypeName == "FileResult" && m.Name == "DownloadReport") {
+        WriteLine("            return await RestCallFileAsync(\"" + m.HttpVerb.ToUpper() + "\", path, " + (m.BodyParam == null ? "null" : "model") + ").ConfigureAwait(false);");
     } else {
         WriteLine("            return await RestCallAsync<" + m.ResponseTypeName + ">(\"" + m.HttpVerb.ToUpper() + "\", path, " + (m.BodyParam == null ? "null" : "model") + ").ConfigureAwait(false);");
     }

--- a/scripts/templates/csharp_api_class.txt
+++ b/scripts/templates/csharp_api_class.txt
@@ -60,6 +60,13 @@ namespace Avalara.AvaTax.RestClient
 		WriteLine("            string endDate = null; ");
 		WriteLine("            if (start != null)");
 		WriteLine("            {");
+		WriteLine("			      startDate = string.Format(\"{0}{1}\", start.Value.ToString(\"s\"), \"Z\");");
+		WriteLine("            }");
+		
+		WriteLine("            if (end != null)");
+		WriteLine("            {");
+		WriteLine("			      endDate = string.Format(\"{0}{1}\", end.Value.ToString(\"s\"), \"Z\");");
+		WriteLine("            }");
 	}
 
     WriteLine(")");
@@ -71,7 +78,12 @@ namespace Avalara.AvaTax.RestClient
         if (p.TypeName == "DateTime") {
             cleanParamName = p.CleanParamName + ".ToString(\"o\")";
         }
-        if (p.ParameterLocation == ParameterLocationType.UriPath) {
+
+		if (m.Name == "AuditAccount" && cleanParamName == "start") {
+			WriteLine("            path.AddQuery(\"start\", startDate);");
+		} else if (m.Name == "AuditAccount" && cleanParamName == "end") {
+			WriteLine("            path.AddQuery(\"end\", endDate);");
+		} else if (p.ParameterLocation == ParameterLocationType.UriPath) {
             WriteLine("            path.ApplyField(\"{0}\", {1});", p.ParamName, cleanParamName);
         } else if (p.ParameterLocation == ParameterLocationType.QueryString) {
             WriteLine("            path.AddQuery(\"{0}\", {1});", p.ParamName, cleanParamName);

--- a/scripts/templates/csharp_api_class.txt
+++ b/scripts/templates/csharp_api_class.txt
@@ -55,6 +55,13 @@ namespace Avalara.AvaTax.RestClient
         Backtrack(2);
     }
 
+	if(m.Name == "AuditAccount") {
+		WriteLine("            string startDate = null;");
+		WriteLine("            string endDate = null; ");
+		WriteLine("            if (start != null)");
+		WriteLine("            {");
+	}
+
     WriteLine(")");
     WriteLine("        {");
     WriteLine("            var path = new AvaTaxPath(\"" + m.URI + "\");");

--- a/scripts/templates/csharp_api_class.txt
+++ b/scripts/templates/csharp_api_class.txt
@@ -162,6 +162,8 @@ namespace Avalara.AvaTax.RestClient
 		WriteLine("            return await RestCallStringAsync(\"" + m.HttpVerb.ToUpper() + "\", path, " + (string.IsNullOrEmpty(paramName) ? "null" : paramName) + ").ConfigureAwait(false);");
 	} else if (m.ResponseTypeName == "String") {
         WriteLine("            return await RestCallStringAsync(\"" + m.HttpVerb.ToUpper() + "\", path, " + (m.BodyParam == null ? "null" : "model") + ").ConfigureAwait(false);");
+    } else if (m.ResponseTypeName == "FileResult") {
+        WriteLine("            return RestCallFileAsync + m.HttpVerb.ToUpper() + "\", path, " + (m.BodyParam == null ? "null" : "model") + ");");
     } else {
         WriteLine("            return await RestCallAsync<" + m.ResponseTypeName + ">(\"" + m.HttpVerb.ToUpper() + "\", path, " + (m.BodyParam == null ? "null" : "model") + ").ConfigureAwait(false);");
     }

--- a/scripts/templates/javascript_api_class.txt
+++ b/scripts/templates/javascript_api_class.txt
@@ -84,7 +84,10 @@ export default class AvaTaxClient {
       },
       body: JSON.stringify(payload)
     }).then(res => {
-      if (res.headers._headers['content-type'][0] === 'application/vnd.ms-excel') {
+	  var contentType = res.headers._headers['content-type'][0];
+
+      if (contentType === 'application/vnd.ms-excel' || contentType === 'text/csv') {
+      {
         return res;
       }
       return res.json();


### PR DESCRIPTION
These fixes are included in this update: 

- https://github.com/avadev/AvaTax-REST-V2-JS-SDK/pull/77
- https://github.com/avadev/AvaTax-REST-V2-DotNet-SDK/pull/82/files
- https://github.com/avadev/AvaTax-REST-V2-DotNet-SDK/pull/114